### PR TITLE
Return in combination with ctrl or alt will exit code block edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "draft-js": "0.x",
-    "draft-js-code": "0.3.x"
+    "draft-js-code": "0.3.x",
+    "immutable": "^3.8.2"
   }
 }

--- a/src/modifiers/insertEmptyBlock.js
+++ b/src/modifiers/insertEmptyBlock.js
@@ -1,0 +1,52 @@
+import { genKey, ContentBlock, EditorState } from 'draft-js';
+import { List, Map } from 'immutable';
+
+
+const insertEmptyBlock = (editorState , blockType = 'unstyled', data = {}) => {
+  const contentState = editorState.getCurrentContent();
+  const selection = editorState.getSelection();
+  const key = selection.getStartKey();
+  const currentBlock = contentState.getBlockForKey(key);
+  const emptyBlockKey = genKey();
+  const emptyBlock = new ContentBlock({
+    characterList: List(),
+    depth: 0,
+    key: emptyBlockKey,
+    text: '',
+    type: blockType,
+    data: Map().merge(data)
+  });
+  const blockMap = contentState.getBlockMap();
+  const blocksBefore = blockMap.toSeq().takeUntil((value) => value === currentBlock);
+  const blocksAfter = blockMap.toSeq().skipUntil((value) => value === currentBlock).rest();
+  const augmentedBlocks = [
+    [
+      currentBlock.getKey(),
+      currentBlock,
+    ],
+    [
+      emptyBlockKey,
+      emptyBlock,
+    ],
+  ];
+  const newBlocks = blocksBefore.concat(augmentedBlocks, blocksAfter).toOrderedMap();
+  const focusKey = emptyBlockKey;
+  const newContentState = contentState.merge({
+    blockMap: newBlocks,
+    selectionBefore: selection,
+    selectionAfter: selection.merge({
+      anchorKey: focusKey,
+      anchorOffset: 0,
+      focusKey,
+      focusOffset: 0,
+      isBackward: false,
+    }),
+  });
+  return EditorState.push(
+    editorState,
+    newContentState,
+    'split-block'
+  );
+};
+
+export default insertEmptyBlock;


### PR DESCRIPTION
Thanks for the great work and plugin!

I have small contribution to make, here is the rationale for the proposed PR.
If the document edit starts with a code block its quite of a hassle to continue editing outside the code block continuing with an edit to the following block. This PR resolves the problem by adding more behavior to existing handleReturn functionality now return in combination with either CTRL or ALT used inserts new empty unstyled block after the code block.

BR,
Slobodan

